### PR TITLE
fix the syntax for geonetwork docker environment

### DIFF
--- a/geonetwork/stack.yml
+++ b/geonetwork/stack.yml
@@ -12,9 +12,9 @@ services:
       image: geonetwork
       restart: always
       ports:
-          - 8080:8080
+         - 8080:8080
       environment:
-          DATA_DIR: /var/lib/geonetwork_data
+         - DATA_DIR=/var/lib/geonetwork_data
       volumes:
          - geonetwork:/var/lib/geonetwork_data
 


### PR DESCRIPTION
in the environment stanza of geonetwork's stack.yml:

* added a '-'
* replaced : with =